### PR TITLE
fix: 즐겨찾기 API 호출 시 페이지 크기 제한 준수

### DIFF
--- a/frontend/src/pages/PublicTemplatePage.js
+++ b/frontend/src/pages/PublicTemplatePage.js
@@ -67,7 +67,7 @@ function PublicTemplateContent() {
             try {
                 const workspaceId = localStorage.getItem('selectedWorkspaceId');
                 if (workspaceId) {
-                    const favoriteResponse = await getFavoriteTemplates(workspaceId, 'PUBLIC', { page: 0, size: 1000 });
+                    const favoriteResponse = await getFavoriteTemplates(workspaceId, 'PUBLIC', { page: 0, size: 100 });
                     const favoriteIds = new Set(
                         favoriteResponse.data.content?.map(fav => fav.publicTemplateId).filter(Boolean) || []
                     );


### PR DESCRIPTION
백엔드에서 페이지 크기를 100개로 제한하고 있어 1000개 요청 시 400 에러 발생하던 문제 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)