### PR TITLE
LateLimit

### DIFF
--- a/backend-spring/src/main/java/com/jober/final2teamdrhong/config/RateLimitConfig.java
+++ b/backend-spring/src/main/java/com/jober/final2teamdrhong/config/RateLimitConfig.java
@@ -28,7 +28,7 @@ public class RateLimitConfig {
         public static final int SIGNUP_WINDOW_DURATION_MINUTES = 60;
 
         // 로그인 시도 제한 기본값
-        public static final int LOGIN_REQUESTS_PER_WINDOW = 5;
+        public static final int LOGIN_REQUESTS_PER_WINDOW = 15;
         public static final int LOGIN_WINDOW_DURATION_MINUTES = 15;
 
         // 토큰 갱신 제한 기본값

--- a/backend-spring/src/main/java/com/jober/final2teamdrhong/service/RateLimitService.java
+++ b/backend-spring/src/main/java/com/jober/final2teamdrhong/service/RateLimitService.java
@@ -23,9 +23,9 @@ import java.util.function.Supplier;
  * 
  * 기능별 Rate Limiting 제공:
  * - 이메일 발송: IP당 5분간 3회
- * - 이메일 인증: 이메일당 10분간 5회  
+ * - 이메일 인증: 이메일당 10분간 5회
  * - 회원가입: IP당 1시간간 10회
- * - 로그인: IP당 15분간 5회 + 이메일당 15분간 3회 (이중 체크)
+ * - 로그인: IP당 15분간 15회 + 이메일당 15분간 10회 (이중 체크)
  * - 토큰 갱신: IP당 5분간 10회
  * 
  * Redis 사용 가능시 분산 환경 지원, 불가능시 인메모리 폴백 사용
@@ -184,13 +184,13 @@ public class RateLimitService {
     }
     
     /**
-     * 이메일별 로그인 버킷 설정 (더 엄격한 제한)
-     * 동일 계정에 대한 무차별 대입 공격 방지
+     * 이메일별 로그인 버킷 설정 (적절한 제한)
+     * 동일 계정에 대한 무차별 대입 공격 방지하면서도 사용자 편의성 고려
      */
     private BucketConfiguration createLoginByEmailBucketConfig() {
         return BucketConfiguration.builder()
                 .addLimit(Bandwidth.simple(
-                        3, // 이메일별로는 더 엄격하게 3회로 제한
+                        10, // 이메일별로 10회로 완화 (정상 사용자 배려)
                         Duration.ofMinutes(rateLimitConfig.getLogin().getWindowDurationMinutes())
                 ))
                 .build();


### PR DESCRIPTION
완화된 Rate Limit 설정

| 기능         | 이전 설정    | 새 설정     | 개선 효과   |
|------------|----------|----------|---------|
| 로그인 (IP별)  | 15분간 5회  | 15분간 15회 | 3배 완화   |
| 로그인 (이메일별) | 15분간 3회  | 15분간 10회 | 3.3배 완화 |
| 이메일 발송     | 5분간 3회   | 5분간 3회   | 유지      |
| 회원가입       | 1시간간 10회 | 1시간간 10회 | 유지      |
| 토큰 갱신      | 5분간 10회  | 5분간 10회  | 유지      |

 수정된 파일들
1. RateLimitConfig.java - 로그인 기본값: 5 → 15회
2. RateLimitService.java - 이메일별 로그인: 3 → 10회, 주석 업데이트
3. RateLimitServiceTest.java - 모든 테스트를 새 값에 맞게 수정

 사용자 경험 개선 효과

 이제 가능한 시나리오:
- 로그아웃 → 즉시 재로그인 가능
- 비밀번호 몇 번 틀려도 충분한 재시도 기회
- 같은 IP(회사, 카페)에서 여러 사용자 로그인 가능
- 정상적인 사용 패턴에서 Rate Limit 걸릴 일 거의 없음

여전히 보안은 유지:
- 브루트 포스 공격 방지: 15분간 15회는 여전히 제한적
- 이메일별 제한: 특정 계정 대상 공격도 10회로 제한
- 다양한 공격 벡터 모두 차단 유지
