### PR TITLE
fix(OAuth2): redirect-uri 자동 생성 및 프록시 헤더 처리 설정

### DIFF
--- a/backend-spring/src/main/resources/application-docker-dev.properties
+++ b/backend-spring/src/main/resources/application-docker-dev.properties
@@ -31,5 +31,8 @@ app.environment.development=true
 # Swagger 서버 URL 설정
 app.swagger.server-url=https://dev.notimo.kro.kr/api/
 
-# OAuth2 리다이렉트 URI 설정 (프록시 환경 대응)
-spring.security.oauth2.client.registration.google.redirect-uri=https://dev.notimo.kro.kr/api/login/oauth2/code/google
+# OAuth2 리다이렉트 URI - Spring Security가 자동으로 생성하도록 설정 제거
+# spring.security.oauth2.client.registration.google.redirect-uri=https://dev.notimo.kro.kr/api/login/oauth2/code/google
+
+# 프록시 환경에서 정확한 URI 생성을 위한 헤더 처리 전략
+server.forward-headers-strategy=framework

--- a/backend-spring/src/main/resources/application-docker-prod.properties
+++ b/backend-spring/src/main/resources/application-docker-prod.properties
@@ -21,5 +21,8 @@ app.environment.development=false
 # Swagger 서버 URL 설정
 app.swagger.server-url=https://notimo.kro.kr/api/
 
-# OAuth2 리다이렉트 URI 설정 (프록시 환경 대응)
-spring.security.oauth2.client.registration.google.redirect-uri=https://notimo.kro.kr/api/login/oauth2/code/google
+# OAuth2 리다이렉트 URI - Spring Security가 자동으로 생성하도록 설정 제거
+# spring.security.oauth2.client.registration.google.redirect-uri=https://notimo.kro.kr/api/login/oauth2/code/google
+
+# 프록시 환경에서 정확한 URI 생성을 위한 헤더 처리 전략
+server.forward-headers-strategy=framework


### PR DESCRIPTION
- 명시적 redirect-uri 설정 제거하여 Spring Security가 자동으로 생성하도록 변경
- server.forward-headers-strategy=framework 추가로 Nginx X-Forwarded-* 헤더 처리
- redirect_uri_mismatch 오류 해결을 위한 설정